### PR TITLE
Fix: 로그 파이프라인 Thread Safety 및 데이터 무결성 취약점 수정

### DIFF
--- a/secure-log-core/src/main/java/io/github/hongjungwan/blackbox/core/internal/ResilientLogTransport.java
+++ b/secure-log-core/src/main/java/io/github/hongjungwan/blackbox/core/internal/ResilientLogTransport.java
@@ -147,6 +147,9 @@ public class ResilientLogTransport {
 
     /**
      * Send with retry policy
+     *
+     * FIX P1-5: KafkaProducer.send() is async, so we must call .join() to wait for completion.
+     * Without .join(), exceptions from async send would not trigger retry logic.
      */
     private void sendWithRetry(byte[] data) {
         if (kafkaProducer == null) {
@@ -154,7 +157,8 @@ public class ResilientLogTransport {
         }
 
         retryPolicy.execute(() -> {
-            kafkaProducer.send(config.getKafkaTopic(), data);
+            // FIX P1-5: Call join() to wait for async send completion and catch exceptions
+            kafkaProducer.send(config.getKafkaTopic(), data).join();
         });
     }
 

--- a/secure-log-core/src/main/java/io/github/hongjungwan/blackbox/core/internal/SemanticDeduplicator.java
+++ b/secure-log-core/src/main/java/io/github/hongjungwan/blackbox/core/internal/SemanticDeduplicator.java
@@ -208,10 +208,16 @@ public class SemanticDeduplicator implements AutoCloseable {
 
     /**
      * Shutdown the executor service gracefully.
+     * Invalidates all cache entries to trigger summary emission before shutdown.
      * Waits for pending summary emissions to complete.
      */
     @Override
     public void close() {
+        // FIX P0-2: Invalidate all cache entries before shutdown to trigger summary emissions
+        // This ensures pending deduplicated logs emit their summaries before executor shutdown
+        cache.invalidateAll();
+        cache.cleanUp();
+
         summaryExecutor.shutdown();
         try {
             if (!summaryExecutor.awaitTermination(5, TimeUnit.SECONDS)) {


### PR DESCRIPTION
### 🔒 보안 강화

P0: Critical 수정
- LogTransport: volatile int → AtomicInteger로 변경하여 Race Condition 해결
- SemanticDeduplicator: close() 시 cache.invalidateAll() 추가로 summary 로그 유실 방지

P1: High 수정
- EnhancedLogProcessor: 예외 발생 시 maskedEntry만 fallback 전송하여 PII 평문 노출 방지
- VirtualAsyncAppender: CountDownLatch 도입으로 stop() 시 consumer batch 완료 대기
- ResilientLogTransport: kafkaProducer.send().join() 추가로 Retry 정상 동작 보장